### PR TITLE
Fix Virtual Stump/Custom Map Loading

### DIFF
--- a/Mods/CustomMaps/Manager.cs
+++ b/Mods/CustomMaps/Manager.cs
@@ -97,7 +97,17 @@ namespace Seralyth.Mods.CustomMaps
         {
             string DirectoryTarget = FileUtilities.GetGamePath() + $"/{PluginInfo.BaseDirectory}/CustomScripts/{CustomMapLoader.LoadedMapModId}.luau";
             if (!File.Exists(DirectoryTarget))
-                File.WriteAllText(DirectoryTarget, mapScriptArchives[CustomMapManager.currentRoomMapModId]);
+            {
+                string script = CustomGameMode.LuaScript;
+
+                if (string.IsNullOrEmpty(script) && mapScriptArchives.TryGetValue(CustomMapManager.currentRoomMapModId, out string archived))
+                    script = archived;
+
+                if (string.IsNullOrEmpty(script))
+                    script = "-- This map does not have a Lua script.\n-- You can write your own script here and click \"Run Custom Script\" to execute it.";
+
+                File.WriteAllText(DirectoryTarget, script);
+            }
             Process.Start(DirectoryTarget);
         }
 
@@ -142,8 +152,18 @@ namespace Seralyth.Mods.CustomMaps
         public static CustomMap GetMapByID(long id)
         {
             if (mapCache.TryGetValue(id, out var instance)) return instance;
-            var mapTypes = Assembly.GetExecutingAssembly()
-                .GetTypes()
+
+            Type[] types;
+            try
+            {
+                types = Assembly.GetExecutingAssembly().GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                types = ex.Types.Where(t => t != null).ToArray();
+            }
+
+            var mapTypes = types
                 .Where(t => t.IsClass && !t.IsAbstract && t.IsSubclassOf(typeof(CustomMap)));
 
             foreach (var type in mapTypes)
@@ -155,7 +175,6 @@ namespace Seralyth.Mods.CustomMaps
             }
 
             mapCache[id] = instance;
-
             return instance;
         }
     }

--- a/Mods/Experimental.cs
+++ b/Mods/Experimental.cs
@@ -205,8 +205,18 @@ namespace Seralyth.Mods
 
         public static void CopyCustomGamemodeScript()
         {
-            NotificationManager.SendNotification("<color=grey>[</color><color=green>SUCCESS</color><color=grey>]</color> Copied map script to your clipboard.", 5000);
-            GUIUtility.systemCopyBuffer = CustomGameMode.LuaScript;
+            string script = CustomGameMode.LuaScript;
+
+            if (string.IsNullOrEmpty(script))
+            {
+                NotificationManager.SendNotification("<color=grey>[</color><color=yellow>WARNING</color><color=grey>]</color> This map does not have a Lua script.", 5000);
+                GUIUtility.systemCopyBuffer = "-- This map does not have a Lua script.";
+            }
+            else
+            {
+                NotificationManager.SendNotification("<color=grey>[</color><color=green>SUCCESS</color><color=grey>]</color> Copied map script to your clipboard.", 5000);
+                GUIUtility.systemCopyBuffer = script;
+            }
         }
 
         public static void CopyCustomMapID()


### PR DESCRIPTION
melonloader support added a ref to melonloader.dll which doesnt exist on bepinex only. GetMapByID calls Assembly.GetTypes() and crashes with ReflectionTypeLoadException, so maps get stuck at 50%. added a try/catch to fix that.
also fixed EditUserScript saving empty files because the script was cached in a harmony prefix before the map loads. now it reads CustomGameMode.LuaScript live. if a map has no script it writes a comment instead of leaving the file blank.

same for CopyCustomGamemodeScript